### PR TITLE
modify func's parameter name & refactor

### DIFF
--- a/Sources/GenericNetworkManager/GenericNetworkManager.swift
+++ b/Sources/GenericNetworkManager/GenericNetworkManager.swift
@@ -4,23 +4,16 @@ import Foundation
 final public class GenericNetworkManager {
     //MARK: - Properties
     public static var shared = GenericNetworkManager()
-    private let baseURL: String?
-    
-    //MARK: - Inits
-    public init(baseURL: String? = nil) {
-        self.baseURL = baseURL
-    }
     
     //MARK: - Methods
-    public func fetchData<T: Decodable>(endpoint: String, completion: @escaping (Result<T, Error>) -> Void) {
-        let urlString = (baseURL ?? "") + endpoint
+    public func fetchData<T: Decodable>(with URLString: String, completion: @escaping (Result<T, Error>) -> Void) {
         
-        guard !urlString.isEmpty, let url = URL(string: urlString) else {
+        guard !URLString.isEmpty, let URL = URL(string: URLString) else {
             completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"])))
             return
         }
         
-        URLSession.shared.dataTask(with: url) { data, response, error in
+        URLSession.shared.dataTask(with: URL) { data, response, error in
             if let error = error {
                 completion(.failure(error))
                 return


### PR DESCRIPTION
**The current code refactoring makes the following changes:**

1. Remove the constant 'baseURL' because it is unused in combination with the static shared property;
2. Remove the public init;
3. Modify the parameter name of the 'fetchData' function from 'endpoint' to 'URLString' to correspond logically with the changes;
4. Update the name of the 'url' variable to 'URL'.

_The adjustments were prompted by the utilization of the previously updated version of 'GenericNetworkManager' in the practical implementation._